### PR TITLE
SVG color conversion fixes.

### DIFF
--- a/geoide-domain/src/main/java/nl/idgis/geoide/commons/domain/style/Color.java
+++ b/geoide-domain/src/main/java/nl/idgis/geoide/commons/domain/style/Color.java
@@ -23,13 +23,21 @@ public class Color implements Serializable {
 		}
 		
 		if (rgba.length == 3) {
-			this.rgba = new double[] { rgba[0], rgba[1], rgba[2], 1.0 };
+			this.rgba = createColor (rgba[0], rgba[1], rgba[2], 1.0);
 		} else if (rgba.length == 1) {
-			this.rgba = new double[] { rgba[0], rgba[0], rgba[0], 1.0 };
+			this.rgba = createColor (rgba[0], rgba[0], rgba[0], 1.0);
 		} else if (rgba.length == 4) {
-			this.rgba = new double[] { rgba[0], rgba[1], rgba[2], rgba[3] };
+			this.rgba = createColor (rgba[0], rgba[1], rgba[2], rgba[3]);
 		} else {
 			throw new IllegalArgumentException ("rgba must have 1, 3 or 4 elements");
+		}
+	}
+	
+	private static double[] createColor (final double r, final double g, final double b, final double a) {
+		if (r < 1.0 || g < 1.0 || b < 1.0) {
+			return new double[] { r, g, b, a };
+		} else {
+			return new double[] { r / 255.0, g / 255.0, b / 255.0, a };
 		}
 	}
 	

--- a/geoide-print/src/main/java/nl/idgis/geoide/commons/report/render/OverlayRenderer.java
+++ b/geoide-print/src/main/java/nl/idgis/geoide/commons/report/render/OverlayRenderer.java
@@ -314,9 +314,9 @@ public class OverlayRenderer extends SvgRenderer {
 			String.format (
 				Locale.US, 
 				"#%02X%02X%02X", 
-				(int)(fill.getColor ().getR () * 255.0),
-				(int)(fill.getColor ().getG () * 255.0),
-				(int)(fill.getColor ().getB () * 255.0)
+				(int)(fill.getColor ().getR () * 255.0) & 0xFF,
+				(int)(fill.getColor ().getG () * 255.0) & 0xFF,
+				(int)(fill.getColor ().getB () * 255.0) & 0xFF
 			),
 			fill.getColor ().getA ()
 		);
@@ -331,9 +331,9 @@ public class OverlayRenderer extends SvgRenderer {
 			String.format (
 				Locale.US, 
 				"#%02X%02X%02X", 
-				(int)(stroke.getColor ().getR () * 255.0),
-				(int)(stroke.getColor ().getG () * 255.0),
-				(int)(stroke.getColor ().getB () * 255.0)
+				(int)(stroke.getColor ().getR () * 255.0) & 0xFF,
+				(int)(stroke.getColor ().getG () * 255.0) & 0xFF,
+				(int)(stroke.getColor ().getB () * 255.0) & 0xFF
 			),
 			stroke.getColor ().getA (),
 			stroke.getWidth () * resolution


### PR DESCRIPTION
- Colors in the form [255, 255, 255, 1.0] are properly converted.
- Colors are clamped when converting to hex notation for SVG.

Connects to #119